### PR TITLE
Add setPins() and setSPIFrequency() + misc other begin() changes

### DIFF
--- a/src/Layer1.h
+++ b/src/Layer1.h
@@ -40,6 +40,9 @@ public:
     int init();
     int send_packet(char* data, int len);
 
+    void setPins(int cs, int reset, int dio);
+    void setSPIFrequency(uint32_t frequency);
+
 private:
     uint8_t hex_digit(char ch);
     int isHashNew(char incoming[SHA1_LENGTH]);
@@ -53,6 +56,7 @@ private:
     int _csPin;
     int _resetPin;
     int _DIOPin;
+    uint32_t _spiFrequency;
 };
 
 extern Layer1Class Layer1;

--- a/src/Layer1_LoRa.cpp
+++ b/src/Layer1_LoRa.cpp
@@ -13,7 +13,8 @@ Layer1Class::Layer1Class() :
 
     _csPin(LORA_DEFAULT_CS_PIN),
     _resetPin(LORA_DEFAULT_RESET_PIN),
-    _DIOPin(LORA_DEFAULT_DIO0_PIN)
+    _DIOPin(LORA_DEFAULT_DIO0_PIN),
+    _spiFrequency(100E3)
 
 {
 
@@ -131,24 +132,29 @@ int Layer1Class::DIOPin(){
     return _DIOPin;
 }
 
+void Layer1Class::setPins(int cs, int reset, int dio){
+    _csPin = cs;
+    _resetPin = reset;
+    _DIOPin = dio;
+}
+
+void Layer1Class::setSPIFrequency(uint32_t frequency){
+    _spiFrequency = frequency;
+}
+
 int Layer1Class::init(){ // maybe this should take the pins and spreading factor as inputs?
 
-    pinMode(_csPin, OUTPUT);
-    pinMode(_DIOPin, INPUT);
-
     LoRa.setPins(_csPin, _resetPin, _DIOPin); // set CS, reset, DIO pin
+    LoRa.setSPIFrequency(_spiFrequency);
 
     if (!LoRa.begin(915E6)) {             // initialize ratio at 915 MHz
-        Serial.printf("LoRa init failed. Check your connections.\r\n");
         return _loraInitialized;
     }
 
-    LoRa.setSPIFrequency(100E3);
     LoRa.setSpreadingFactor(9);           // ranges from 6-12,default 7 see API docs
     LoRa.onReceive(onReceive);
     LoRa.receive();
 
-    Serial.printf("LoRa init succeeded.\r\n");
     _loraInitialized = 1;
     return _loraInitialized;
 }


### PR DESCRIPTION
* Added `setPins` and `setSPIFrequency` methods with the same signature as on the `LoRa` class
* Moved `LoRa.setSPIFrequency()` to before `LoRa.begin()`  per documentation https://github.com/sandeepmistry/arduino-LoRa/blob/master/API.md#set-spi-interface
* Removed `pinMode` calls since that's already handled [here](https://github.com/sandeepmistry/arduino-LoRa/blob/master/src/LoRa.cpp#L99) and [here](https://github.com/sandeepmistry/arduino-LoRa/blob/master/src/LoRa.cpp#L355)
* Removed `Serial.printf`s since that should be handled by the consumer of the library.