### PR TITLE
Dual LoRa

### DIFF
--- a/src/Layer1_LoRa.cpp
+++ b/src/Layer1_LoRa.cpp
@@ -9,9 +9,13 @@ Layer1Class::Layer1Class()
   _loraFrequency(915E6),
   _txPower(17),
   _loraInitialized(0),
-  _spiFrequency(100E3){};
+  _spiFrequency(100E3)
+{
+  txBuffer = new packetBuffer();
+  rxBuffer = new packetBuffer();
+};
 
-bool _receivedFlag = false;
+bool _dioFlag = false;
 bool _enableInterrupt = true;
 int _packetSize = 0;
 
@@ -112,7 +116,7 @@ void Layer1Class::setFlag(int packetSize) {
     }
     // we got a packet, set the flag
     _packetSize = packetSize;
-    _receivedFlag = true;
+    _dioFlag = true;
 }
 
 /*Main public functions
@@ -137,7 +141,7 @@ int Layer1Class::init(){
 
 // Transmit polling function
 int Layer1Class::transmit(){
-    BufferEntry entry = txBuffer.read();
+    BufferEntry entry = txBuffer->read();
     if(entry.length != 0){
         sendPacket(entry.data, entry.length);
     }
@@ -147,10 +151,10 @@ int Layer1Class::transmit(){
 // Receive polling function
 int Layer1Class::receive(){
     int ret = 0; 
-    if(_receivedFlag) {
+    if(_dioFlag) {
         Serial.printf("Layer1Class::receive(): _packetSize = %d\r\n", _packetSize);
         _enableInterrupt = false;
-        _receivedFlag = false;
+        _dioFlag = false;
         if (_packetSize > 0){
             char data[MAX_PACKET_SIZE];
             int len = 0;
@@ -161,7 +165,7 @@ int Layer1Class::receive(){
             BufferEntry entry;
             memcpy(&entry.data[0], &data[0], len);
             entry.length = len;
-            rxBuffer.write(entry);
+            rxBuffer->write(entry);
 
             #ifdef LL2_DEBUG
             Serial.printf("Layer1::receive(): data = ");

--- a/src/Layer1_LoRa.h
+++ b/src/Layer1_LoRa.h
@@ -29,8 +29,8 @@ public:
     void setTxPower(int txPower);
 
     // Fifo buffers
-    packetBuffer txBuffer;
-    packetBuffer rxBuffer;
+    packetBuffer *txBuffer;
+    packetBuffer *rxBuffer;
 
     // Main public functions
     int init();

--- a/src/Layer1_LoRa.h
+++ b/src/Layer1_LoRa.h
@@ -3,7 +3,9 @@
 
 #include <stdint.h>
 #include <Arduino.h>
+#include <LoRa.h>
 #include <SPI.h>
+#include <packetBuffer.h>
 
 class Layer1Class {
 public:
@@ -12,7 +14,7 @@ public:
     int debug_printf(const char* format, ...);
 
     // Public access to local variables
-    int getTime();
+    static int getTime();
     int loraInitialized();
     int loraCSPin();
     int resetPin();
@@ -26,6 +28,10 @@ public:
     void setSpreadingFactor(uint8_t spreadingFactor);
     void setTxPower(int txPower);
 
+    // Fifo buffers
+    packetBuffer txBuffer;
+    packetBuffer rxBuffer;
+
     // Main public functions
     int init();
     int transmit();
@@ -33,7 +39,7 @@ public:
 
 private:
     // Main private functions
-    static void setFlag(void);
+    static void setFlag(int packetSize);
     int sendPacket(char *data, size_t len);
 
     // Local variables

--- a/src/Layer1_LoRa.h
+++ b/src/Layer1_LoRa.h
@@ -1,0 +1,49 @@
+#ifndef LAYER1_H
+#define LAYER1_H
+
+#include <stdint.h>
+#include <Arduino.h>
+#include <SPI.h>
+
+class Layer1Class {
+public:
+    Layer1Class();
+
+    int debug_printf(const char* format, ...);
+
+    // Public access to local variables
+    int getTime();
+    int loraInitialized();
+    int loraCSPin();
+    int resetPin();
+    int DIOPin();
+    int spreadingFactor();
+
+    // User configurable settings
+    void setPins(int cs, int reset, int dio);
+    void setSPIFrequency(uint32_t frequency);
+    void setLoRaFrequency(uint32_t frequency);
+    void setSpreadingFactor(uint8_t spreadingFactor);
+    void setTxPower(int txPower);
+
+    // Main public functions
+    int init();
+    int transmit();
+    int receive();
+
+private:
+    // Main private functions
+    static void setFlag(void);
+    int sendPacket(char *data, size_t len);
+
+    // Local variables
+    int _csPin;
+    int _resetPin;
+    int _DIOPin;
+    uint8_t _spreadingFactor;
+    uint32_t _loraFrequency;
+    int _txPower;
+    int _loraInitialized;
+    uint32_t _spiFrequency;
+};
+#endif

--- a/src/Layer1_SX1276.cpp
+++ b/src/Layer1_SX1276.cpp
@@ -1,5 +1,5 @@
+#ifdef RL_SX1276
 #include <Layer1_SX1276.h>
-//#ifdef RL_SX1276
 Layer1Class::Layer1Class(SX1276 *lora, int mode, int cs, int reset, int dio, uint8_t sf, uint32_t frequency, int power) 
 : _LoRa{lora}, 
   _mode(mode),
@@ -116,4 +116,4 @@ int Layer1Class::receive(){
     }
     return ret;
 }
-//#endif
+#endif

--- a/src/Layer1_SX1276.cpp
+++ b/src/Layer1_SX1276.cpp
@@ -83,12 +83,11 @@ int Layer1Class::init(){
 
 // Transmit polling function
 int Layer1Class::transmit(){
-    char *data = txBuffer.read();
-    size_t len = (size_t)data[1]; //this is a small hack to get the packet length by inspecting the byte where it is store in the packet
-    if(len != 0){
-        sendPacket(data, len);
+    BufferEntry entry = txBuffer.read();
+    if(entry.length != 0){
+        sendPacket(entry.data, entry.length);
     }
-    return len;
+    return entry.length;
 }
 
 // Receive polling function
@@ -101,7 +100,10 @@ int Layer1Class::receive(){
         byte data[len];
         int state = _LoRa->readData(data, len);
         if (state == ERR_NONE) {
-          rxBuffer.write((char*)data, len);
+          BufferEntry entry;
+          memcpy(&data, &entry, len);
+          entry.length = len;
+          rxBuffer.write(entry);
         } else if (state == ERR_CRC_MISMATCH) {
             // packet was received, but is malformed
             ret=1;

--- a/src/Layer1_SX1276.cpp
+++ b/src/Layer1_SX1276.cpp
@@ -1,0 +1,117 @@
+#include <Layer1_SX1276.h>
+//#ifdef RL_SX1276
+Layer1Class::Layer1Class(SX1276 *lora, int mode, int cs, int reset, int dio, uint8_t sf, uint32_t frequency, int power) 
+: _LoRa{lora}, 
+  _mode(mode),
+  _csPin(cs),
+  _resetPin(reset),
+  _DIOPin(dio),
+  _spreadingFactor(sf),
+  _loraFrequency(frequency),
+  _txPower(power),
+  _loraInitialized(0),
+  _spiFrequency(100E3),
+  _bandwidth(125.0), 
+  _codingRate(5),
+  _syncWord(SX127X_SYNC_WORD), 
+  _currentLimit(100),
+  _preambleLength(8),
+  _gain(0){};
+
+bool _receivedFlag = false;
+bool _enableInterrupt = true;
+
+/* Public access to local variables
+ */
+int Layer1Class::getTime(){
+    return millis();
+}
+
+int Layer1Class::spreadingFactor(){
+    return _spreadingFactor;
+}
+
+/* Private functions
+*/
+// Send packet function
+int Layer1Class::sendPacket(char* data, size_t len){
+    int ret = 0;
+    int state = _LoRa->transmit((byte*)data, len);
+    if (state == ERR_PACKET_TOO_LONG) {
+      // packet longer than 256 bytes
+      ret = 1;
+    } else if (state == ERR_TX_TIMEOUT) {
+      // timeout occurred while transmitting packet
+      ret = 2;
+    } else {
+      // some other error occurred
+      ret = 3;
+  }
+  return ret;
+}
+
+// Receive packet callback
+void Layer1Class::setFlag(void) {
+    // check if the interrupt is enabled
+    if(!_enableInterrupt) {
+        return;
+    }
+    // we got a packet, set the flag
+    _receivedFlag = true;
+}
+
+/*Main public functions
+*/
+// Initialization
+int Layer1Class::init(){
+
+    int state = _LoRa->begin(_loraFrequency, _bandwidth, _spreadingFactor, _codingRate, SX127X_SYNC_WORD, _txPower, _currentLimit, _preambleLength, _gain); 
+    if (state != ERR_NONE) {
+      return _loraInitialized;
+    }
+
+    _LoRa->setDio0Action(Layer1Class::setFlag);
+
+    state = _LoRa->startReceive();
+    if (state != ERR_NONE) {
+      return _loraInitialized;
+    }
+
+    _loraInitialized = 1;
+    return _loraInitialized;
+}
+
+// Transmit polling function
+int Layer1Class::transmit(){
+    char *data = txBuffer.read();
+    size_t len = (size_t)data[1]; //this is a small hack to get the packet length by inspecting the byte where it is store in the packet
+    if(len != 0){
+        sendPacket(data, len);
+    }
+    return len;
+}
+
+// Receive polling function
+int Layer1Class::receive(){
+    int ret = 0; 
+    if(_receivedFlag) {
+        _enableInterrupt = false;
+        _receivedFlag = false;
+        size_t len =_LoRa->getPacketLength();
+        byte data[len];
+        int state = _LoRa->readData(data, len);
+        if (state == ERR_NONE) {
+          rxBuffer.write((char*)data, len);
+        } else if (state == ERR_CRC_MISMATCH) {
+            // packet was received, but is malformed
+            ret=1;
+        } else {
+            // some other error occurred
+            ret=2;
+        }
+        _LoRa->startReceive();
+        _enableInterrupt = true;
+    }
+    return ret;
+}
+//#endif

--- a/src/Layer1_SX1276.h
+++ b/src/Layer1_SX1276.h
@@ -21,8 +21,8 @@ public:
     int spreadingFactor();
 
     // Fifo buffers
-    packetBuffer txBuffer;
-    packetBuffer rxBuffer;
+    packetBuffer *txBuffer;
+    packetBuffer *rxBuffer;
 
     // Main public functions
     int init();

--- a/src/Layer1_SX1276.h
+++ b/src/Layer1_SX1276.h
@@ -1,0 +1,56 @@
+#ifndef LAYER1_H
+#define LAYER1_H
+
+#include <unistd.h>
+#include <stdint.h>
+#include <stdarg.h>
+
+#include <Arduino.h>
+#include <RadioLib.h>
+#include <SPI.h>
+
+#include <packetBuffer.h>
+
+class Layer1Class {
+
+public:
+    Layer1Class(SX1276 *lora, int mode, int cs, int reset, int dio, uint8_t sf = 9, uint32_t frequency = 915, int power = 17); 
+    
+    // Public access to local variables
+    static int getTime();
+    int spreadingFactor();
+
+    // Fifo buffers
+    packetBuffer txBuffer;
+    packetBuffer rxBuffer;
+
+    // Main public functions
+    int init();
+    int transmit();
+    int receive();
+
+private:
+    // Main private functions
+    static void setFlag(void);
+    int sendPacket(char *data, size_t len);
+
+    // Local variables
+    SX1276 *_LoRa;
+    int _mode;
+    int _csPin;
+    int _resetPin;
+    int _DIOPin;
+    uint8_t _spreadingFactor;
+    uint32_t _loraFrequency;
+    int _txPower;
+    int _loraInitialized;
+    uint32_t _spiFrequency;
+    float _bandwidth; 
+    uint8_t _codingRate;
+    uint8_t _syncWord; //SX127X_SYNC_WORD, 
+    uint8_t _currentLimit;
+    uint8_t _preambleLength;
+    uint8_t _gain;
+};
+
+#endif

--- a/src/Layer1_Sim.cpp
+++ b/src/Layer1_Sim.cpp
@@ -1,6 +1,6 @@
-#include <Layer1.h>
-#include <LoRaLayer2.h>
 #ifdef SIM
+#include <Layer1_Sim.h>
+#include <LoRaLayer2.h>
 
 Layer1Class::Layer1Class()
 {

--- a/src/Layer1_Sim.h
+++ b/src/Layer1_Sim.h
@@ -1,0 +1,42 @@
+#ifndef LAYER1_H
+#define LAYER1_H
+
+#include <stdint.h>
+
+#define STDIN 0
+#define STDOUT 1
+#define SHA1_LENGTH 40
+
+#include <stdio.h>
+#include <string.h> // for memcmp and memset functions
+#include <math.h>  // for ceil and pow functions
+
+class Layer1Class {
+public:
+    Layer1Class();
+    int simulationTime(int realTime);
+    int setTimeDistortion(float newDistortion);
+    int getTime();
+    void setTime(int millis);
+    int spreadingFactor();
+    int setNodeID(int newID);
+    int nodeID();
+
+    int parse_metadata(char* data, uint8_t len);
+    int begin_packet();
+    int transmit();
+
+private:
+    int sendPacket(char* data, uint8_t len);
+    float timeDistortion();
+
+    int _transmitting;
+    int _nodeID;
+    float _timeDistortion;
+    uint8_t _spreadingFactor;
+    long _millis;
+
+};
+
+extern Layer1Class Layer1;
+#endif

--- a/src/LoRaLayer2.cpp
+++ b/src/LoRaLayer2.cpp
@@ -559,9 +559,6 @@ int LL2Class::init(){
     _startTime = Layer1Class::getTime();
     _lastRoutingTime = _startTime;
     _lastTransmitTime = _startTime;
-    //setAddress(_loopbackAddr, "00000000");
-    //setAddress(_broadcastAddr, "ffffffff");
-    //setAddress(_routingAddr, "afffffff");
     return 0;
 }
 
@@ -581,6 +578,9 @@ int LL2Class::daemon(){
     if (Layer1Class::getTime() - _lastTransmitTime > _dutyInterval){
         int length = LoRa1->transmit();
         if(length > 0){
+          #ifdef LL2_DEBUG
+          Serial.printf("LL2::daemon(): transmitted packet of length: %d\r\n", length);
+          #endif
           _lastTransmitTime = Layer1Class::getTime();
           double airtime = calculateAirtime((double)length, (double)LoRa1->spreadingFactor(), 1, 0, 5, 125);
           _dutyInterval = (int)ceil(airtime/_dutyCycle);
@@ -592,7 +592,9 @@ int LL2Class::daemon(){
     // first check if any interrupts have been set,
     // then check if any packets have been added to Layer1 rxbuffer
     if(LoRa1->receive() > 0){
+        #ifdef LL2_DEBUG
         Serial.printf("LL2Class::daemon: received packet\r\n");
+        #endif
         receive();
     }
 

--- a/src/LoRaLayer2.h
+++ b/src/LoRaLayer2.h
@@ -127,7 +127,7 @@ private:
     void receive();
 
     // Fifo buffer objects
-    packetBuffer rxBuffer; // L2 sending to L3
+    packetBuffer *rxBuffer; // L2 sending to L3
     // NOTE: there is no L2 txBuffer (i.e. L3 sending to L2 a packet to be transmitted) because I have not found a need for one yet
 
     // Local members, variables and tables

--- a/src/LoRaLayer2.h
+++ b/src/LoRaLayer2.h
@@ -5,6 +5,22 @@
 #include <stdint.h>
 #include <stdarg.h>
 
+#include <Arduino.h>
+
+#ifdef ARDUINO_LORA
+#include <Layer1_LoRa.h>
+#endif
+
+#ifdef RL_SX1276
+#include <Layer1_SX1276.h>
+#endif
+
+#ifdef SIM
+#include <Layer1_Sim.h>
+#endif
+
+#include <packetBuffer.h>
+
 //#define DEBUG 0
 #define HEADER_LENGTH 17
 #define PACKET_LENGTH 256
@@ -15,7 +31,10 @@
 #define MAX_ROUTES_PER_PACKET 40 
 #define ASYNC_TX 1
 #define DEFAULT_TTL 30
-#define BUFFERSIZE 16
+
+extern uint8_t BROADCAST[ADDR_LENGTH];
+extern uint8_t LOOPBACK[ADDR_LENGTH];
+extern uint8_t ROUTING[ADDR_LENGTH];
 
 struct Datagram {
     uint8_t destination[ADDR_LENGTH];
@@ -50,35 +69,25 @@ struct RoutingTableEntry{
     uint8_t metric;
 };
 
-class packetBuffer {
-  public:
-    Packet read();
-    int write(Packet packet);
-    packetBuffer();
-  private:
-    Packet buffer[BUFFERSIZE];
-    int head;
-    int tail;
-};
-
 class LL2Class {
 public:
+    // Constructor
+    LL2Class(Layer1Class *lora_1, Layer1Class *lora_2 = NULL);
+
     // Public access to local variables
     uint8_t messageCount();
+
     uint8_t* localAddress();
-    uint8_t* broadcastAddr();
-    uint8_t* loopbackAddr();
-    uint8_t* routingAddr();
     int getRouteEntry();
 
     // User configurable settings
-    int setLocalAddress(const char* macString);
+    void setLocalAddress(const char* macString);
     long setInterval(long interval);
     void setDutyCycle(double dutyCycle);
 
     // Wrappers for packetBuffers
-    void writePacket(uint8_t* data, size_t length);
-    Packet readPacket();
+    //void writePacket(uint8_t* data, size_t length);
+    //Packet readPacket();
     int writeData(Datagram datagram, size_t length);
     Packet readData();
 
@@ -90,9 +99,6 @@ public:
     // Main init and loop functions
     int init();
     int daemon();
-
-    // Constructor
-    LL2Class();
 
 private:
     // General purpose utility functions
@@ -119,30 +125,28 @@ private:
     void receive();
 
     // Fifo buffer objects
-    packetBuffer L2toL1; // L2 sending to L1
-    packetBuffer L1toL2; // L1 sending to L2
-    packetBuffer L2toL3; // L2 sending to L3
-    // NOTE: there is no L3toL2 buffer because I have not found a need for one yet
+    packetBuffer rxBuffer; // L2 sending to L3
+    // NOTE: there is no L2 txBuffer (i.e. L3 sending to L2 a packet to be transmitted) because I have not found a need for one yet
 
-    // Local variables and tables
+    // Local members, variables and tables
     uint8_t _localAddress[ADDR_LENGTH];
-    uint8_t _loopbackAddr[ADDR_LENGTH];
-    uint8_t _broadcastAddr[ADDR_LENGTH];
-    uint8_t _routingAddr[ADDR_LENGTH];
+
+    Layer1Class *LoRa1;
+    Layer1Class *LoRa2;
     uint8_t _messageCount;
     float _packetSuccessWeight;
-    NeighborTableEntry _neighborTable[255];
     int _neighborEntry;
-    RoutingTableEntry _routeTable[255];
     int _routeEntry;
-    long _startTime;
-    long _lastRoutingTime;
     int _routingInterval;
     int _disableRoutingPackets;
-    long _lastTransmitTime;
     int _dutyInterval;
     double _dutyCycle;
+
+    long _startTime;
+    long _lastRoutingTime;
+    long _lastTransmitTime;
+    NeighborTableEntry _neighborTable[255];
+    RoutingTableEntry _routeTable[255];
 };
 
-extern LL2Class LL2;
 #endif

--- a/src/LoRaLayer2.h
+++ b/src/LoRaLayer2.h
@@ -85,9 +85,7 @@ public:
     long setInterval(long interval);
     void setDutyCycle(double dutyCycle);
 
-    // Wrappers for packetBuffers
-    //void writePacket(uint8_t* data, size_t length);
-    //Packet readPacket();
+    // Layer 3 tx/rx wrappers
     int writeData(Datagram datagram, size_t length);
     Packet readData();
 
@@ -101,6 +99,10 @@ public:
     int daemon();
 
 private:
+    // Wrappers for packetBuffers
+    int writeToBuffer(packetBuffer *buffer, Packet packet);
+    Packet readFromBuffer(packetBuffer *buffer);
+
     // General purpose utility functions
     uint8_t hexDigit(char ch);
     void setAddress(uint8_t* addr, const char* macString);

--- a/src/packetBuffer.cpp
+++ b/src/packetBuffer.cpp
@@ -10,15 +10,18 @@ packetBuffer::packetBuffer()
 
 // reads a packet from buffer
 BufferEntry packetBuffer::read(){
-    // clear tmp_data of any previous packet data
-    BufferEntry entry;
-    memset(&entry, 0, sizeof(entry));
-    if (head != tail){
-      tail = (tail + 1) % BUFFERSIZE;
-      // copy contents of buffer tail to tmp_data
-      memcpy(&entry, &buffer[tail], entry.length);
+    if (head == tail){
+        // if buffer empty, return empty entry
+        BufferEntry entry;
+        memset(&entry.data, 0, sizeof(entry.data));
+        entry.length = 0;
+        return entry;
     }
-    return entry;
+    else{
+        // otherwise return entry from tail
+        tail = (tail + 1) % BUFFERSIZE;
+        return buffer[tail];
+    }
 }
 
 // writes a packet to buffer

--- a/src/packetBuffer.cpp
+++ b/src/packetBuffer.cpp
@@ -1,0 +1,36 @@
+#include <LoRaLayer2.h>
+
+/* Fifo Buffer Class
+*/
+packetBuffer::packetBuffer()
+{
+    head = 0;
+    tail = 0;
+}
+
+// reads a packet from buffer
+char* packetBuffer::read(){
+    // clear tmp_data of any previous packet data
+    memset(&tmp_data, 0, sizeof(tmp_data));
+    if (head != tail){
+      tail = (tail + 1) % BUFFERSIZE;
+      // copy contents of buffer tail to tmp_data
+      memcpy(&tmp_data, &buffer[tail][0], sizeof(tmp_data));
+    }
+    return tmp_data;
+}
+
+// writes a packet to buffer
+int packetBuffer::write(char data[MAX_PACKET_SIZE], size_t len) {
+    int ret = BUFFERSIZE;
+    // if full, return the size of the buffer
+    if (((head + 1) % BUFFERSIZE) != tail){
+        head = (head + 1) % BUFFERSIZE;
+        // clear any previous data stored in buffer
+        memset(&buffer[head][0], 0, sizeof(buffer[head][0]));
+        // copy new data into buffer
+        memcpy(&buffer[head][0], &data[0], len);
+        ret = head-tail; // and return the packet's place in line
+    }
+    return ret;
+}

--- a/src/packetBuffer.cpp
+++ b/src/packetBuffer.cpp
@@ -2,26 +2,29 @@
 
 /* Fifo Buffer Class
 */
-packetBuffer::packetBuffer()
+packetBuffer::packetBuffer() :
+  head(0),
+  tail(0)
 {
-    head = 0;
-    tail = 0;
-}
+};
 
 // reads a packet from buffer
 BufferEntry packetBuffer::read(){
+    BufferEntry entry;
     if (head == tail){
         // if buffer empty, return empty entry
         BufferEntry entry;
-        memset(&entry.data, 0, sizeof(entry.data));
+        memset(&entry, 0, sizeof(entry));
         entry.length = 0;
-        return entry;
     }
     else{
         // otherwise return entry from tail
         tail = (tail + 1) % BUFFERSIZE;
-        return buffer[tail];
+        memcpy(&entry, &buffer[tail], sizeof(entry));
+        // clear data stored in tail of buffer
+        memset(&buffer[tail], 0, sizeof(buffer[tail]));
     }
+    return entry;
 }
 
 // writes a packet to buffer

--- a/src/packetBuffer.cpp
+++ b/src/packetBuffer.cpp
@@ -9,28 +9,30 @@ packetBuffer::packetBuffer()
 }
 
 // reads a packet from buffer
-char* packetBuffer::read(){
+BufferEntry packetBuffer::read(){
     // clear tmp_data of any previous packet data
-    memset(&tmp_data, 0, sizeof(tmp_data));
+    BufferEntry entry;
+    memset(&entry, 0, sizeof(entry));
     if (head != tail){
       tail = (tail + 1) % BUFFERSIZE;
       // copy contents of buffer tail to tmp_data
-      memcpy(&tmp_data, &buffer[tail][0], sizeof(tmp_data));
+      memcpy(&entry, &buffer[tail], entry.length);
     }
-    return tmp_data;
+    return entry;
 }
 
 // writes a packet to buffer
-int packetBuffer::write(char data[MAX_PACKET_SIZE], size_t len) {
+int packetBuffer::write(BufferEntry entry) {
     int ret = BUFFERSIZE;
     // if full, return the size of the buffer
     if (((head + 1) % BUFFERSIZE) != tail){
         head = (head + 1) % BUFFERSIZE;
         // clear any previous data stored in buffer
-        memset(&buffer[head][0], 0, sizeof(buffer[head][0]));
+        memset(&buffer[head], 0, sizeof(buffer[head]));
         // copy new data into buffer
-        memcpy(&buffer[head][0], &data[0], len);
+        buffer[head] = entry;
         ret = head-tail; // and return the packet's place in line
     }
+    // if full, return the size of the buffer
     return ret;
 }

--- a/src/packetBuffer.h
+++ b/src/packetBuffer.h
@@ -9,8 +9,8 @@
 #define MAX_PACKET_SIZE 255
 
 struct BufferEntry {
-  char data[MAX_PACKET_SIZE];
-  size_t length;
+  char data[MAX_PACKET_SIZE] = { 0 };
+  size_t length = 0;
 };
 
 class packetBuffer {

--- a/src/packetBuffer.h
+++ b/src/packetBuffer.h
@@ -5,19 +5,22 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <stdarg.h>
-//#include <LoRaLayer2.h>
 #define BUFFERSIZE 16
 #define MAX_PACKET_SIZE 255
+
+struct BufferEntry {
+  char data[MAX_PACKET_SIZE];
+  size_t length;
+};
 
 class packetBuffer {
   public:
     // use pointer to char instead? and then copy that raw data into a packet
-    char* read();
-    int write(char data[MAX_PACKET_SIZE], size_t len);
+    BufferEntry read();
+    int write(BufferEntry entry);
     packetBuffer();
   private:
-    char buffer[BUFFERSIZE][MAX_PACKET_SIZE];
-    char tmp_data[MAX_PACKET_SIZE];
+    BufferEntry buffer[BUFFERSIZE];
     int head;
     int tail;
 };

--- a/src/packetBuffer.h
+++ b/src/packetBuffer.h
@@ -1,0 +1,24 @@
+#ifndef PACKETBUFFER_H
+#define PACKETBUFFER_H
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <stdarg.h>
+//#include <LoRaLayer2.h>
+#define BUFFERSIZE 16
+#define MAX_PACKET_SIZE 255
+
+class packetBuffer {
+  public:
+    // use pointer to char instead? and then copy that raw data into a packet
+    char* read();
+    int write(char data[MAX_PACKET_SIZE], size_t len);
+    packetBuffer();
+  private:
+    char buffer[BUFFERSIZE][MAX_PACKET_SIZE];
+    char tmp_data[MAX_PACKET_SIZE];
+    int head;
+    int tail;
+};
+#endif


### PR DESCRIPTION
This merge request rewrites how the user of this library interacts with the Layer1 and LoRaLayer2 classes and adds preliminary support for dual LoRa modules. Now users must create their own Layer1Class and LL2Class, instead of being provided with a global class object. This is intended to make the library more modular.

A major change has  also been made to the structure of the Layer1 headers and the dependencies of the cpp files. I have separated the headers so there is one header per cpp file, which more standard. The Layer1 and packetBuffer source code are no longer dependent on LoRaLayer2.h, while LoRaLayer2 is dependent on Layer1 (you can specific which you would like to use by adding the correct build flag). Both Layer1 and LoRaLayer2 depend on packetBuffer.h.

TODO:
* Update router beacon example and API docs
* Sync simulator code to confirm that Layer1_Sim still works properly