### PR TITLE
Sender receiver example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 examples/.pio
 examples/lib
+.vscode/

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# Examples
+## routerbeacon/
+Basic router that relays datagrams from neighbors
+
+## sender/
+Generates a datagram and sends to a specific target address
+
+## receiver/
+Receives datagrams from a sender with the reciever being the destination for the sender

--- a/examples/receiver/.gitignore
+++ b/examples/receiver/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/receiver/platformio.ini
+++ b/examples/receiver/platformio.ini
@@ -1,0 +1,19 @@
+;PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:heltec_wifi_lora_32_V2]
+platform = espressif32
+framework = arduino
+upload_port = /dev/ttyUSB0
+monitor_port = /dev/ttyUSB0
+monitor_speed = 9600
+lib_deps = https://github.com/sudomesh/LoRaLayer2#6d6d8059acb922ddc26766b3b6de353f8752ca00
+build_flags = -DARDUINO_LORA -DLL2_DEBUG
+board = heltec_wifi_lora_32_V2 

--- a/examples/receiver/src/main.cpp
+++ b/examples/receiver/src/main.cpp
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+//LoRaLayer2
+#include <Layer1_LoRa.h>
+#include <LoRaLayer2.h>
+#define LL2_DEBUG
+
+// For Heltec ESP32 LoRa V2 - Update for your board / region
+#define LORA_CS 18
+#define LORA_RST 14
+#define LORA_IRQ 26
+#define LORA_FREQ 915E6
+#define LED 25
+#define TX_POWER 20
+
+char MAC[9] = "c0d3f00d";
+uint8_t LOCAL_ADDRESS[ADDR_LENGTH] = {0xc0, 0xd3, 0xf0, 0x0d};
+// GATEWAY is the receiver 
+uint8_t GATEWAY[ADDR_LENGTH] = {0xc0, 0xd3, 0xf0, 0x0c};
+
+Layer1Class *Layer1;
+LL2Class *LL2;
+
+int counter = 0;
+
+void setup() {
+  SPI.begin(5, 19, 27, 18);
+  Serial.begin(9600);
+  while (!Serial);
+
+  Serial.println("* Initializing LoRa...");
+  Serial.println("LoRa Receiver");
+
+  Layer1 = new Layer1Class();
+  Layer1->setPins(LORA_CS, LORA_RST, LORA_IRQ);
+  Layer1->setTxPower(TX_POWER);
+  Layer1->setLoRaFrequency(LORA_FREQ);
+  if (Layer1->init())
+  {
+    Serial.println(" --> LoRa initialized");
+    LL2 = new LL2Class(Layer1); // initialize Layer2
+    LL2->setLocalAddress(MAC); // this should either be randomized or set using the wifi mac address
+    LL2->setInterval(10000); // set to zero to disable routing packets
+  }
+  else
+  {
+    Serial.println(" --> Failed to initialize LoRa");
+  }
+}
+
+void loop() {
+  LL2->daemon();
+
+  struct Packet packet = LL2->readData();
+  if(packet.totalLength > HEADER_LENGTH)
+  {
+    Serial.println(((char *)packet.datagram.message));
+  }
+}

--- a/examples/sender/.gitignore
+++ b/examples/sender/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/sender/platformio.ini
+++ b/examples/sender/platformio.ini
@@ -1,0 +1,19 @@
+;PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:heltec_wifi_lora_32_V2]
+platform = espressif32
+framework = arduino
+upload_port = /dev/ttyUSB0
+monitor_port = /dev/ttyUSB0
+monitor_speed = 9600
+lib_deps = https://github.com/sudomesh/LoRaLayer2#6d6d8059acb922ddc26766b3b6de353f8752ca00
+build_flags = -DARDUINO_LORA -DLL2_DEBUG
+board = heltec_wifi_lora_32_V2 

--- a/examples/sender/src/main.cpp
+++ b/examples/sender/src/main.cpp
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+//LoRaLayer2
+#include <Layer1_LoRa.h>
+#include <LoRaLayer2.h>
+#define LL2_DEBUG
+
+// For Heltec ESP32 LoRa V2 - Update for your board / region
+#define LORA_CS 18
+#define LORA_RST 14
+#define LORA_IRQ 26
+#define LORA_FREQ 915E6
+#define LED 25
+#define TX_POWER 20
+
+char MAC[9] = "c0d3f00d";
+uint8_t LOCAL_ADDRESS[ADDR_LENGTH] = {0xc0, 0xd3, 0xf0, 0x0d};
+// GATEWAY is the receiver 
+uint8_t GATEWAY[ADDR_LENGTH] = {0xc0, 0xd3, 0xf0, 0x0c};
+
+Layer1Class *Layer1;
+LL2Class *LL2;
+
+int counter = 0;
+
+void setup() {
+  SPI.begin(5, 19, 27, 18);
+  Serial.begin(9600);
+  while (!Serial);
+
+  Serial.println("* Initializing LoRa...");
+  Serial.println("LoRa Sender");
+
+  Layer1 = new Layer1Class();
+  Layer1->setPins(LORA_CS, LORA_RST, LORA_IRQ);
+  Layer1->setTxPower(TX_POWER);
+  Layer1->setLoRaFrequency(LORA_FREQ);
+  if (Layer1->init())
+  {
+    Serial.println(" --> LoRa initialized");
+    LL2 = new LL2Class(Layer1); // initialize Layer2
+    LL2->setLocalAddress(MAC); // this should either be randomized or set using the wifi mac address
+    LL2->setInterval(10000); // set to zero to disable routing packets
+  }
+  else
+  {
+    Serial.println(" --> Failed to initialize LoRa");
+  }
+}
+
+void loop() {
+  LL2->daemon();
+  int msglen = 0;
+  int packetsize = 0;
+
+  struct Datagram datagram; 
+  msglen = sprintf((char*)datagram.message, "%s,%i", "hello", counter); 
+  memcpy(datagram.destination, GATEWAY, ADDR_LENGTH);
+  datagram.type = 's'; // can be anything, but 's' for 'sensor'
+
+  packetsize = msglen + HEADER_LENGTH;
+
+  // Send packet
+  LL2->writeData(datagram, packetsize);
+  counter++;
+
+  Serial.println((char*)datagram.message);
+  delay(1000);
+}


### PR DESCRIPTION
Adds a sender and receiver example. 

I wasn't sure how to use the same projectio configuration for both, so I broke them in to two separate projects as to not conflict with the routerbeacon. I think there can only be one `src_dir`, so a tree of `examples/*` kinda throws a wrench in it. 

Thanks again for your help in figuring this out!